### PR TITLE
add queries about whether specific items are allowed by policies

### DIFF
--- a/1.6/Defs/ThingQueries.xml
+++ b/1.6/Defs/ThingQueries.xml
@@ -100,6 +100,9 @@
 			<li>Query_AssignOutfit</li>
 			<li>Query_AssignFood</li>
 			<li>Query_AssignDrug</li>
+			<li>Query_AssignOutfitThing</li>
+			<li>Query_AssignFoodThing</li>
+			<li>Query_AssignDrugThing</li>
 		</subQueries>
 	</TD_Find_Lib.ThingQueryCategoryDef>
 
@@ -262,6 +265,24 @@
 		<defName>Query_AssignDrug</defName>
 		<label>drug policy</label>
 		<queryClass>TD_Find_Lib.ThingQueryDrugPolicy</queryClass>
+	</TD_Find_Lib.ThingQueryDef>
+
+	<TD_Find_Lib.ThingQueryDef>
+		<defName>Query_AssignOutfitThing</defName>
+		<label>allowed by apparel policy</label>
+		<queryClass>TD_Find_Lib.ThingQueryOutfitThing</queryClass>
+	</TD_Find_Lib.ThingQueryDef>
+
+	<TD_Find_Lib.ThingQueryDef>
+		<defName>Query_AssignFoodThing</defName>
+		<label>allowed by food restriction</label>
+		<queryClass>TD_Find_Lib.ThingQueryFoodRestrictionThing</queryClass>
+	</TD_Find_Lib.ThingQueryDef>
+
+	<TD_Find_Lib.ThingQueryDef>
+		<defName>Query_AssignDrugThing</defName>
+		<label>allowed by drug policy</label>
+		<queryClass>TD_Find_Lib.ThingQueryDrugPolicyThing</queryClass>
 	</TD_Find_Lib.ThingQueryDef>
 	
 

--- a/Source/ThingQuery/Queries/QueryPawn.cs
+++ b/Source/ThingQuery/Queries/QueryPawn.cs
@@ -1185,6 +1185,96 @@ namespace TD_Find_Lib
 	}
 
 
+	public class ThingQueryOutfitThing : ThingQueryCategorizedDropdown<ThingDef, string, ThingQueryThingDef, ThingQueryThingDefCategory>
+	{
+		public ThingQueryOutfitThing()
+		{
+			sel = ThingDefOf.Apparel_Parka;
+		}
+
+		public override bool Ordered => true;
+
+		public override IEnumerable<ThingDef> AllOptions() =>
+			base.AllOptions().Where(def => ValidDef(def) && IsApparel(def));
+		public override IEnumerable<ThingDef> AvailableOptions() =>
+			ContentsUtility.AvailableInGame(t => IsApparel(t.def) ? t.def : null);
+
+		public override ThingDef IconDefFor(ThingDef o) => o;//duh
+
+		public override string CategoryFor(ThingDef def) => ThingQueryThingDefCategory.CategoryFor(def);
+
+		public override bool AppliesDirectly2(Thing thing) =>
+			(thing as Pawn)?.outfits?.CurrentApparelPolicy.filter.Allows(sel) ?? false;
+
+		private bool IsApparel(ThingDef def) => typeof(Apparel).IsAssignableFrom(def.thingClass);
+	}
+
+	public class ThingQueryFoodRestrictionThing : ThingQueryCategorizedDropdown<ThingDef, string, ThingQueryThingDef, ThingQueryThingDefCategory>
+	{
+		public ThingQueryFoodRestrictionThing()
+		{
+			sel = ThingDefOf.MealSimple;
+		}
+
+		public override bool Ordered => true;
+
+		public override IEnumerable<ThingDef> AllOptions() =>
+			base.AllOptions().Where(def => ValidDef(def) && IsFood(def));
+		public override IEnumerable<ThingDef> AvailableOptions() =>
+			ContentsUtility.AvailableInGame(t => IsFood(t.def) ? t.def : null);
+
+		public override ThingDef IconDefFor(ThingDef o) => o;//duh
+
+		public override string CategoryFor(ThingDef def) => ThingQueryThingDefCategory.CategoryFor(def);
+
+		public override bool AppliesDirectly2(Thing thing) =>
+			(thing as Pawn)?.foodRestriction?.CurrentFoodPolicy.filter.Allows(sel) ?? false;
+
+		// From Dialog_ManageFoodPolicies.
+		private bool IsFood(ThingDef def) => def.GetStatValueAbstract(StatDefOf.Nutrition) > 0f;
+	}
+
+
+	public class ThingQueryDrugPolicyThing : ThingQueryCategorizedDropdown<ThingDef, string, ThingQueryThingDef, ThingQueryThingDefCategory>
+	{
+		public ThingQueryDrugPolicyThing()
+		{
+			sel = ThingDefOf.Penoxycyline;
+		}
+
+		public override bool Ordered => true;
+
+		public override IEnumerable<ThingDef> AllOptions() =>
+			base.AllOptions().Where(def => ValidDef(def) && IsDrug(def));
+		public override IEnumerable<ThingDef> AvailableOptions() =>
+			ContentsUtility.AvailableInGame(t => IsDrug(t.def) ? t.def : null);
+
+		public override ThingDef IconDefFor(ThingDef o) => o;//duh
+
+		public override string CategoryFor(ThingDef def) => ThingQueryThingDefCategory.CategoryFor(def);
+
+		public override bool AppliesDirectly2(Thing thing)
+		{
+			Pawn pawn = thing as Pawn;
+			DrugPolicyEntry entry = pawn?.drugs?.CurrentPolicy?[sel];
+			if( pawn == null || entry == null )
+			    return false;
+			return (entry.allowedForAddiction && IsAddicted(pawn, entry.drug)) | entry.allowedForJoy | entry.allowScheduled;
+		}
+
+		private static bool IsAddicted(Pawn pawn, ThingDef drug)
+		{
+			if(AddictionUtility.HasChemicalDependency(pawn, drug))
+				return true;
+			ChemicalDef chemicalDef = drug.GetCompProperties<CompProperties_Drug>()?.chemical;
+			if(chemicalDef == null)
+				return false;
+			return AddictionUtility.IsAddicted(pawn, chemicalDef);
+		}
+
+		private bool IsDrug(ThingDef def) => def.IsDrug;
+	}
+
 	public class ThingQueryWork : ThingQueryDropDown<WorkTypeDef>
 	{
 		public ThingQueryWork()


### PR DESCRIPTION
For example, a bill to make a shield belt can be set for every colonist that has an apparel policy allowing a shield belt. The advantage to the existing policy queries is that this updates automatically whenever policies are changed in any way.